### PR TITLE
Thrift version hack for cadence

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module go.uber.org/cadence
 
-go 1.13
+go 1.16
 
 require (
-	github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7
+	github.com/apache/thrift v0.13.0 // indirect
+	github.com/apache/thrift/thriftV0100 v0.0.0-20161221203622-b2a4d4ae21c7
 	github.com/cristalhq/jwt/v3 v3.1.0
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a
 	github.com/gogo/protobuf v1.3.2
@@ -32,3 +33,5 @@ require (
 	golang.org/x/time v0.0.0-20170927054726-6dc17368e09b
 	honnef.co/go/tools v0.0.1-2019.2.3
 )
+
+replace github.com/apache/thrift/thriftV0100 => github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7 h1:Fv9bK1Q+ly/ROk4aJsVMeuIwPel4bEnD8EPiI91nZMg=
 github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
+github.com/apache/thrift v0.13.0 h1:5hryIiq9gtn+MiLVn0wP37kb/uTeRZgN08WoCsAhIhI=
+github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/internal/common/thrift_util.go
+++ b/internal/common/thrift_util.go
@@ -23,21 +23,22 @@ package common
 import (
 	"reflect"
 
-	"github.com/apache/thrift/lib/go/thrift"
+	// "github.com/apache/thrift/lib/go/thrift"
+	thriftV0100 "github.com/apache/thrift/thriftV0100/lib/go/thrift"
 )
 
 // TSerialize is used to serialize thrift TStruct to []byte
-func TSerialize(t thrift.TStruct) (b []byte, err error) {
-	return thrift.NewTSerializer().Write(t)
+func TSerialize(t thriftV0100.TStruct) (b []byte, err error) {
+	return thriftV0100.NewTSerializer().Write(t)
 }
 
 // TListSerialize is used to serialize list of thrift TStruct to []byte
-func TListSerialize(ts []thrift.TStruct) (b []byte, err error) {
+func TListSerialize(ts []thriftV0100.TStruct) (b []byte, err error) {
 	if ts == nil {
 		return
 	}
 
-	t := thrift.NewTSerializer()
+	t := thriftV0100.NewTSerializer()
 	t.Transport.Reset()
 
 	// NOTE: we don't write any markers as thrift by design being a streaming protocol doesn't
@@ -45,7 +46,7 @@ func TListSerialize(ts []thrift.TStruct) (b []byte, err error) {
 
 	for _, v := range ts {
 		if e := v.Write(t.Protocol); e != nil {
-			err = thrift.PrependError("error writing TStruct: ", e)
+			err = thriftV0100.PrependError("error writing TStruct: ", e)
 			return
 		}
 	}
@@ -63,13 +64,13 @@ func TListSerialize(ts []thrift.TStruct) (b []byte, err error) {
 }
 
 // TDeserialize is used to deserialize []byte to thrift TStruct
-func TDeserialize(t thrift.TStruct, b []byte) (err error) {
-	return thrift.NewTDeserializer().Read(t, b)
+func TDeserialize(t thriftV0100.TStruct, b []byte) (err error) {
+	return thriftV0100.NewTDeserializer().Read(t, b)
 }
 
 // TListDeserialize is used to deserialize []byte to list of thrift TStruct
-func TListDeserialize(ts []thrift.TStruct, b []byte) (err error) {
-	t := thrift.NewTDeserializer()
+func TListDeserialize(ts []thriftV0100.TStruct, b []byte) (err error) {
+	t := thriftV0100.NewTDeserializer()
 	err = nil
 	if _, err = t.Transport.Write(b); err != nil {
 		return
@@ -77,7 +78,7 @@ func TListDeserialize(ts []thrift.TStruct, b []byte) (err error) {
 
 	for i := 0; i < len(ts); i++ {
 		if e := ts[i].Read(t.Protocol); e != nil {
-			err = thrift.PrependError("error reading TStruct: ", e)
+			err = thriftV0100.PrependError("error reading TStruct: ", e)
 			return
 		}
 	}
@@ -85,7 +86,7 @@ func TListDeserialize(ts []thrift.TStruct, b []byte) (err error) {
 	return
 }
 
-// IsUseThriftEncoding checks if the objects passed in are all encoded using thrift.
+// IsUseThriftEncoding checks if the objects passed in are all encoded using thriftV0100.
 func IsUseThriftEncoding(objs []interface{}) bool {
 	// NOTE: our criteria to use which encoder is simple if all the types are serializable using thrift then we use
 	// thrift encoder. For everything else we default to gob.
@@ -102,7 +103,7 @@ func IsUseThriftEncoding(objs []interface{}) bool {
 	return true
 }
 
-// IsUseThriftDecoding checks if the objects passed in are all de-serializable using thrift.
+// IsUseThriftDecoding checks if the objects passed in are all de-serializable using thriftV0100.
 func IsUseThriftDecoding(objs []interface{}) bool {
 	// NOTE: our criteria to use which encoder is simple if all the types are de-serializable using thrift then we use
 	// thrift decoder. For everything else we default to gob.
@@ -128,6 +129,6 @@ func IsThriftType(v interface{}) bool {
 	if reflect.ValueOf(v).Kind() != reflect.Ptr {
 		return false
 	}
-	t := reflect.TypeOf((*thrift.TStruct)(nil)).Elem()
+	t := reflect.TypeOf((*thriftV0100.TStruct)(nil)).Elem()
 	return reflect.TypeOf(v).Implements(t)
 }

--- a/internal/encoding.go
+++ b/internal/encoding.go
@@ -27,7 +27,8 @@ import (
 	"io"
 	"reflect"
 
-	"github.com/apache/thrift/lib/go/thrift"
+	// "github.com/apache/thrift/lib/go/thrift"
+	thriftV0100 "github.com/apache/thrift/thriftV0100/lib/go/thrift"
 	"go.uber.org/cadence/internal/common"
 )
 
@@ -75,12 +76,12 @@ type thriftEncoding struct{}
 
 // Marshal encodes an array of thrift into bytes
 func (g thriftEncoding) Marshal(objs []interface{}) ([]byte, error) {
-	var tlist []thrift.TStruct
+	var tlist []thriftV0100.TStruct
 	for i := 0; i < len(objs); i++ {
 		if !common.IsThriftType(objs[i]) {
-			return nil, fmt.Errorf("pointer to thrift.TStruct type is required for %v argument", i+1)
+			return nil, fmt.Errorf("pointer to thriftV0100.TStruct type is required for %v argument", i+1)
 		}
-		t := reflect.ValueOf(objs[i]).Interface().(thrift.TStruct)
+		t := reflect.ValueOf(objs[i]).Interface().(thriftV0100.TStruct)
 		tlist = append(tlist, t)
 	}
 	return common.TListSerialize(tlist)
@@ -88,13 +89,13 @@ func (g thriftEncoding) Marshal(objs []interface{}) ([]byte, error) {
 
 // Unmarshal decodes an array of thrift into bytes
 func (g thriftEncoding) Unmarshal(data []byte, objs []interface{}) error {
-	var tlist []thrift.TStruct
+	var tlist []thriftV0100.TStruct
 	for i := 0; i < len(objs); i++ {
 		rVal := reflect.ValueOf(objs[i])
 		if rVal.Kind() != reflect.Ptr || !common.IsThriftType(reflect.Indirect(rVal).Interface()) {
-			return fmt.Errorf("pointer to pointer thrift.TStruct type is required for %v argument", i+1)
+			return fmt.Errorf("pointer to pointer thriftV0100.TStruct type is required for %v argument", i+1)
 		}
-		t := reflect.New(rVal.Elem().Type().Elem()).Interface().(thrift.TStruct)
+		t := reflect.New(rVal.Elem().Type().Elem()).Interface().(thriftV0100.TStruct)
 		tlist = append(tlist, t)
 	}
 


### PR DESCRIPTION
Re-implementing the cadence client hack from the original WH repo.

This repo was recreated as a fork from the original Uber repo so that we can pull latest as needed.